### PR TITLE
Add optional SHA256 check

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ options:
   --key KEY             key to decrypt the file (default: None)
   --proxy PROXY         proxy to use (default: None)
   --md5 MD5             md5 to check the file (default: None)
+  --sha256 MD5          sha256 to check the file (default: None)
   --max-redirect-hops MAX_REDIRECT_HOPS
                         max redirect hops (default: 3)
   --verify VERIFY       verify the file (default: None)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ download("https://raw.githubusercontent.com/fedebotu/robust-downloader/main/READ
 ```bash
 $ robust-downloader --help
 usage: robust-downloader [-h] [-V] [--folder FOLDER] [--filename FILENAME] [--key KEY]
-                         [--proxy PROXY] [--md5 MD5]
+                         [--proxy PROXY] [--md5 MD5] [--sha256 SHA256]
                          [--max-redirect-hops MAX_REDIRECT_HOPS] [--verify VERIFY]
                          [--timeout TIMEOUT] [--retry-max RETRY_MAX]
                          [--sleep-max SLEEP_MAX] [--chunk-size CHUNK_SIZE]
@@ -58,7 +58,7 @@ options:
   --key KEY             key to decrypt the file (default: None)
   --proxy PROXY         proxy to use (default: None)
   --md5 MD5             md5 to check the file (default: None)
-  --sha256 MD5          sha256 to check the file (default: None)
+  --sha256 SHA256       sha256 to check the file (default: None)
   --max-redirect-hops MAX_REDIRECT_HOPS
                         max redirect hops (default: 3)
   --verify VERIFY       verify the file (default: None)

--- a/robust_downloader/cli.py
+++ b/robust_downloader/cli.py
@@ -32,6 +32,7 @@ def main():
     parser.add_argument("--key", help="key to decrypt the file")
     parser.add_argument("--proxy", help="proxy to use")
     parser.add_argument("--md5", help="md5 to check the file")
+    parser.add_argument("--sha256", help="sha256 to check the file")
     parser.add_argument(
         "--max-redirect-hops", type=int, default=3, help="max redirect hops"
     )
@@ -52,6 +53,7 @@ def main():
         key=args.key,
         proxy=args.proxy,
         md5=args.md5,
+        sha256=args.sha256,
         max_redirect_hops=args.max_redirect_hops,
         verify=args.verify,
         timeout=args.timeout,


### PR DESCRIPTION
This PR adds an option to check using SHA256 instead of MD5.

I like to use SHA256 as collisions are much less likely. Not neccessarily a huge problem for occasional downloads
But SHA256 is widely used for file validation and only MD5 makes it difficult to use in these scenarios.